### PR TITLE
Adds a 'textUpdates' event triggered when an element's text is substitut...

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ Publicly exposed events may be found as part of `localeEvents` situated within t
 
 - `localeEvents.resourceUpdates`: when a new language file is pulled into memory
 - `localeEvents.localeChanges`: when the user chooses a different locale
+- `localeEvents.textUpdates`: when an element's text is set to its translation
+
+__NOTE:__ The `localeEvents.textUpdates` is only sent for substitutions triggered by the `i18n` and `i18nAttr` directives.
 
 ```js
 angular.module('myApp', [
@@ -184,6 +187,9 @@ angular.module('myApp', [
         });
         $scope.$on(localeEvents.localeChanges, function (event, data) {
             console.log('new locale chosen: ' + data);
+        });
+        $scope.$on(localeEvents.textUpdates, function (event, element) {
+            console.log('translation set for: ' + element);
         });
     }
 ]);

--- a/src/localization.events.js
+++ b/src/localization.events.js
@@ -1,5 +1,6 @@
 angular.module('ngLocalize.Events', [])
     .constant('localeEvents', {
         resourceUpdates: 'ngLocalizeResourcesUpdated',
-        localeChanges: 'ngLocalizeLocaleChanged'
+        localeChanges: 'ngLocalizeLocaleChanged',
+        textUpdates: 'ngLocalizeTextUpdated'
     });

--- a/src/localization.js
+++ b/src/localization.js
@@ -267,12 +267,14 @@ angular.module('ngLocalize', ['ngSanitize', 'ngLocalize.Config', 'ngLocalize.Eve
             };
         }
     ])
-    .directive('i18n', ['$sce', 'locale', 'localeEvents', 'localeConf',
-        function ($sce, locale, localeEvents, localeConf) {
+    .directive('i18n', ['$sce', '$rootScope', 'locale', 'localeEvents', 'localeConf',
+        function ($sce, $rootScope, locale, localeEvents, localeConf) {
             function setText(elm, tag) {
                 if (tag !== elm.html()) {
                     elm.html($sce.getTrustedHtml(tag));
                 }
+
+                $rootScope.$broadcast(localeEvents.textUpdates, elm);
             }
 
             function update(elm, string, optArgs) {
@@ -315,8 +317,8 @@ angular.module('ngLocalize', ['ngSanitize', 'ngLocalize.Config', 'ngLocalize.Eve
             };
         }
     ])
-    .directive('i18nAttr', ['locale', 'localeEvents',
-        function (locale, localeEvents) {
+    .directive('i18nAttr', ['$rootScope', 'locale', 'localeEvents',
+        function ($rootScope, locale, localeEvents) {
             return function (scope, elem, attrs) {
                 var lastValues = {};
 
@@ -342,12 +344,14 @@ angular.module('ngLocalize', ['ngSanitize', 'ngLocalize.Config', 'ngLocalize.Eve
                                 attrs.$set(key, lastValues[key] = value);
                             }
                         }
+
+                        $rootScope.$broadcast(localeEvents.textUpdates, target);
                     });
                 }
 
                 attrs.$observe('i18nAttr', function (newVal, oldVal) {
                     if (newVal && newVal != oldVal) {
-                        updateText(elem, newVal); 
+                        updateText(elem, newVal);
                     }
                 });
 


### PR DESCRIPTION
...ed using the directives.

This comes from the same need as described in issue #25, that is to be notified when translations are being substituted.

The PR adds a new 'textUpdates' event that is triggered for every element being affected by the i18n and i18nAttr directives. The element is passed as a parameter to the broadcasted event. The Readme is also updated to reflect that addition.