### PR TITLE
Add method to load a localised bundle

### DIFF
--- a/src/localization.js
+++ b/src/localization.js
@@ -258,6 +258,23 @@ angular.module('ngLocalize', ['ngSanitize', 'ngLocalize.Config', 'ngLocalize.Eve
             }
         }
 
+        /**
+         * Returns the localized bundle given the bundle path.
+         * Note that this will not load the bundle if it's not already loaded.
+         * Therefore you should wrap this inside a call to ready
+         * @param path the name of the bundle to retrieve
+         * @returns {*} the bundle
+         */
+        function getLocalizedBundle(path) {
+            var key = path + ".-";
+            var bundle = getBundle(key);
+            if (bundle && !bundle._loading) {
+                return bundle;
+            } else {
+                return null;
+            }
+        }
+
         function getLocale() {
             return currentLocale;
         }
@@ -271,7 +288,8 @@ angular.module('ngLocalize', ['ngSanitize', 'ngLocalize.Config', 'ngLocalize.Eve
             getKey: getKey,
             setLocale: setLocale,
             getLocale: getLocale,
-            getString: getLocalizedString
+            getString: getLocalizedString,
+            getBundle: getLocalizedBundle
         };
     })
     .filter('i18n', function (locale) {

--- a/tests/unit/serviceSpec.js
+++ b/tests/unit/serviceSpec.js
@@ -35,5 +35,24 @@ describe('service', function () {
         it('should validate tokens with whitespace', inject(function (locale) {
             expect(locale.isToken('test.hello world')).toBe(true);
         }));
+
+        it('should return a bundle object', inject(function (locale) {
+            inject(function ($injector) {
+                // Set up the mock http service responses
+                var _httpBackend = $injector.get('$httpBackend');
+                // backend definition common for all tests
+                _httpBackend.whenGET('languages/en-US/common.lang.json').respond({
+                    helloWorld: 'Hello World'
+                });
+
+                // force our service to pull down the required resource file
+                $injector.get('locale').ready('common');
+                _httpBackend.flush();
+            });
+
+            locale.ready('common');
+            var o = locale.getBundle('common');
+            expect(o.helloWorld).toEqual('Hello World');
+        }));
     });
 });


### PR DESCRIPTION
This adds a method to access a localised bundle.
This is used to allow me to use angular-localization to load a complete bundle into another package which has its own i18n system.

I see there is also a request for this, or something similar [here](https://github.com/doshprompt/angular-localization/issues/49) so this might also cover this request.