### PR TITLE
Use window.navigator.language if no language cookie is set.

### DIFF
--- a/src/localization.js
+++ b/src/localization.js
@@ -262,7 +262,7 @@ angular.module('ngLocalize')
             return currentLocale;
         }
 
-        setLocale(cookieStore ? cookieStore.get(localeConf.cookieName) : $window.navigator.userLanguage || $window.navigator.language);
+        setLocale(cookieStore.get(localeConf.cookieName) ? cookieStore.get(localeConf.cookieName) : $window.navigator.userLanguage || $window.navigator.language);
 
         return {
             ready: ready,

--- a/src/localization.js
+++ b/src/localization.js
@@ -262,7 +262,7 @@ angular.module('ngLocalize')
             return currentLocale;
         }
 
-        setLocale(cookieStore.get(localeConf.cookieName) ? cookieStore.get(localeConf.cookieName) : $window.navigator.userLanguage || $window.navigator.language);
+        setLocale(cookieStore && cookieStore.get(localeConf.cookieName) ? cookieStore.get(localeConf.cookieName) : $window.navigator.userLanguage || $window.navigator.language);
 
         return {
             ready: ready,


### PR DESCRIPTION
`cookieStore` always evaluates to `true` if `persistSelection` is `true` and `$injector.has('$cookieStore')`. This means that ngLocalize will not use a user's default language. Instead, it will just default to the `defaultLocale`. In my opinion, this is not the desired behavior.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/doshprompt/angular-localization/53)
<!-- Reviewable:end -->
