### PR TITLE
Update the lang attribute of the html tag when the locale changes

### DIFF
--- a/src/localization.js
+++ b/src/localization.js
@@ -2,6 +2,7 @@ angular.module('ngLocalize')
     .service('locale', function ($injector, $http, $q, $log, $rootScope, $window, localeConf, localeEvents, localeSupported, localeFallbacks) {
         var TOKEN_REGEX = new RegExp('^[\\w\\.-]+\\.[\\w\\s\\.-]+\\w(:.*)?$'),
 
+            $html = angular.element(document.body).parent(),
             currentLocale,
             deferrences,
             bundles,
@@ -227,6 +228,12 @@ angular.module('ngLocalize')
             return result;
         }
 
+        function updateHtmlTagLangAttr(lang) {
+            lang = lang.split('-')[0];
+
+            $html.attr('lang', lang);
+        }
+
         function setLocale(value) {
             var lang;
 
@@ -248,6 +255,8 @@ angular.module('ngLocalize')
                 bundles = {};
                 deferrences = {};
                 currentLocale = lang;
+
+                updateHtmlTagLangAttr(lang);
 
                 $rootScope.$broadcast(localeEvents.localeChanges, currentLocale);
                 $rootScope.$broadcast(localeEvents.resourceUpdates);

--- a/tests/unit/serviceSpec.js
+++ b/tests/unit/serviceSpec.js
@@ -35,5 +35,10 @@ describe('service', function () {
         it('should validate tokens with whitespace', inject(function (locale) {
             expect(locale.isToken('test.hello world')).toBe(true);
         }));
+
+        it('should update the lang attribute of the html tag', inject(function (locale) {
+            locale.setLocale('en-US');
+            expect(angular.element(document.body).parent().attr('lang')).toBe('en');
+        }));
     });
 });


### PR DESCRIPTION
Angular-localization will now update the `lang` attribute
of the root `html` tag to match the current locale's language

This closes #22 because users can now use the lang
attribute in their css to change the direction of the
document and/or add any other language specific css

Example:

```css
html[lang=ar] {
  direction: rtl;
}
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/doshprompt/angular-localization/56)
<!-- Reviewable:end -->
