### PR TITLE
feat(i18nAttr): Normalize the attribute key before it is set

### DIFF
--- a/src/localization.directives.js
+++ b/src/localization.directives.js
@@ -68,7 +68,7 @@ angular.module('ngLocalize')
                         exp = values[key];
                         value = locale.getString(exp);
                         if (lastValues[key] !== value) {
-                            attrs.$set(key, lastValues[key] = value);
+                            attrs.$set(attrs.$normalize(key), lastValues[key] = value);
                         }
                     }
                 });


### PR DESCRIPTION
Normalize the attribute key before it is set. The attrs object will retain the camel case name while element attributes will be converted using snake case. Please refer to https://github.com/angular/angular.js/blob/v1.4.5/src/ng/compile.js#L1095-L1102.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/doshprompt/angular-localization/60)
<!-- Reviewable:end -->
