### PR TITLE
Arbitrarily deep nesting of *.lang.json files

### DIFF
--- a/src/localization.config.js
+++ b/src/localization.config.js
@@ -2,6 +2,7 @@ angular.module('ngLocalize.Config', [])
     .value('localeConf', {
         basePath: 'languages',
         defaultLocale: 'en-US',
+        sharedPrefix: '',
         sharedDictionary: 'common',
         fileExtension: '.lang.json',
         persistSelection: true,

--- a/src/localization.js
+++ b/src/localization.js
@@ -62,7 +62,7 @@ angular.module('ngLocalize')
         function loadBundle(token) {
             var path = token ? token.split('.') : '',
                 root = bundles,
-                url = localeConf.basePath + '/' + currentLocale,
+                url = localeConf.basePath + '/' + currentLocale + localeConf.sharedPrefix,
                 i;
 
             if (path.length > 1) {


### PR DESCRIPTION
This change allows you to specify a config option for deep nesting *after* the language/country code prefix. It's an issue that came up with our content management system where many types of content are behind our country/language code prefix, and we had to put localization labels for angular several layers deeper in the url than normal. 

### Blank `sharedPrefix` behaves like existing config

```javascript
...
basePath: '/labels',
defaultLocale: 'en-US',
sharedPrefix: '',
fileExtension: '.lang.json',
...

{{'common.greeting' | i18n}}  //source url: /labels/en-US/common.lang.json
```

### Adding `sharedPrefix` allows deeper nesting

```javascript
...
basePath: '/labels',
defaultLocale: 'en-US',
sharedPrefix: '/content',
fileExtension: '.lang.json',
...

{{'common.greeting' | i18n}}  //source url: /labels/en-US/content/common.lang.json
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/doshprompt/angular-localization/61)
<!-- Reviewable:end -->
