### PR TITLE
chore(gulp): Remove gulp newer plugin

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,7 +36,6 @@ gulp.task('scripts', function() {
     var filename = pkg.name + '.js';
 
     return gulp.src(SRC_FILES)
-        .pipe($.newer(path.join(DIST_DIR, filename)))
         .pipe($.angularFilesort())
         .pipe($.addSrc.prepend('module.prefix'))
         .pipe($.addSrc.append('module.suffix'))
@@ -70,7 +69,6 @@ gulp.task('styles', function() {
     var filename = pkg.name + '.css';
 
     return gulp.src('src/**/*.less')
-        .pipe($.newer(path.join(DIST_DIR, filename)))
         .pipe($.sourcemaps.init())
         .pipe($.less())
         .pipe($.concat(filename))

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "gulp-jshint": "^1.11.2",
     "gulp-less": "^3.0.3",
     "gulp-load-plugins": "^0.10.0",
-    "gulp-newer": "^0.5.1",
     "gulp-ng-annotate": "^0.5.2",
     "gulp-preprocess": "^1.1.1",
     "gulp-rename": "^1.2.2",


### PR DESCRIPTION
Remove gulp newer plugin. Ran into an issue where running `gulp` over a previous build resulted in no code between the module wrapper.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/doshprompt/angular-localization/69)
<!-- Reviewable:end -->
