### PR TITLE
Added resolving of the JSON data

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ angular.module('myApp', ['ngLocalize'])
 
 As you can see, The `locale` service expects the localization key as the first argument and an optional {Object|Array|String} with user data as the second argument.
 
-The promise returns the object containing the localization key & values: 
+The promise returns the object containing the localization keys & values: 
 
 ```js
 angular.module('myApp', ['ngLocalize'])

--- a/README.md
+++ b/README.md
@@ -322,6 +322,20 @@ angular.module('myApp', ['ngLocalize'])
 
 As you can see, The `locale` service expects the localization key as the first argument and an optional {Object|Array|String} with user data as the second argument.
 
+The promise returns an array where the first variable is the string given, and the 2nd argument is the data object: 
+
+```js
+angular.module('myApp', ['ngLocalize'])
+    .controller('exampleCtrl', ['$scope', 'locale',
+        function ($scope, locale) {
+            locale.ready('common').then(function (res) {
+                //res[0] --> common
+                //res[1] --> { "helloWorld" : "Hello World!", ... }
+            });
+        }
+    ]);
+```
+
 ### i18n filter
 
 The `i18n` filter provides the same functionality as the service.  

--- a/README.md
+++ b/README.md
@@ -322,15 +322,14 @@ angular.module('myApp', ['ngLocalize'])
 
 As you can see, The `locale` service expects the localization key as the first argument and an optional {Object|Array|String} with user data as the second argument.
 
-The promise returns an array where the first variable is the string given, and the 2nd argument is the data object: 
+The promise returns the object containing the localization key & values: 
 
 ```js
 angular.module('myApp', ['ngLocalize'])
     .controller('exampleCtrl', ['$scope', 'locale',
         function ($scope, locale) {
             locale.ready('common').then(function (res) {
-                //res[0] --> common
-                //res[1] --> { "helloWorld" : "Hello World!", ... }
+                //res --> { "helloWorld" : "Hello World!", ... }
             });
         }
     ]);

--- a/dist/angular-localization.js
+++ b/dist/angular-localization.js
@@ -119,7 +119,7 @@ angular.module('ngLocalize')
 
                             // If we issued a Promise for this file, resolve it now.
                             if (deferrences[path]) {
-                                deferrences[path].resolve([path, data]);
+                                deferrences[path].resolve(data);
                             }
                         })
                         .error(function () {
@@ -146,7 +146,7 @@ angular.module('ngLocalize')
             }
 
             if (bundle && !bundle._loading) {
-                deferrences[path].resolve([path, bundle]);
+                deferrences[path].resolve(bundle);
             } else {
                 if (!bundle) {
                     loadBundle(token);

--- a/dist/angular-localization.js
+++ b/dist/angular-localization.js
@@ -119,7 +119,7 @@ angular.module('ngLocalize')
 
                             // If we issued a Promise for this file, resolve it now.
                             if (deferrences[path]) {
-                                deferrences[path].resolve(path);
+                                deferrences[path].resolve([path, data]);
                             }
                         })
                         .error(function () {
@@ -146,7 +146,7 @@ angular.module('ngLocalize')
             }
 
             if (bundle && !bundle._loading) {
-                deferrences[path].resolve(path);
+                deferrences[path].resolve([path, bundle]);
             } else {
                 if (!bundle) {
                     loadBundle(token);


### PR DESCRIPTION
Resolved the JSON data as well so it is available in the `.then(function (res) { ... })` and the 2nd item in the array. (path remains the first item in what is now an array)

The reason I made it is because I needed to have the keys of the JSOn available in the HTML on an object variable, since I can't use strings in the `ngPluralize` directive. Now I can have the keys available and use localization along with pluralization.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/doshprompt/angular-localization/83)
<!-- Reviewable:end -->
