### PR TITLE
(bugfix) locale.ready() now resolves to data

### DIFF
--- a/src/localization.js
+++ b/src/localization.js
@@ -130,7 +130,7 @@ angular.module('ngLocalize')
 
                             // If we issued a Promise for this file, resolve it now.
                             if (deferrences[path]) {
-                                deferrences[path].resolve(path);
+                                deferrences[path].resolve(data);
                             }
                         })
                         .error(function (err) {


### PR DESCRIPTION
The documentation suggests that locale.ready(some_path) should return a promise that resolves with the data requested rather than the path.

angular.module('myApp', ['ngLocalize'])
    .controller('exampleCtrl', ['$scope', 'locale',
        function ($scope, locale) {
            locale.ready('common').then(function (res) {
                // Before fix:
                // res --> 'common'

                // After fix:
                //res --> { "helloWorld" : "Hello World!", ... }
            });
        }
    ]);