### PR TITLE
add urlbuilder

### DIFF
--- a/src/localization.js
+++ b/src/localization.js
@@ -1,5 +1,5 @@
 angular.module('ngLocalize')
-    .service('locale', function ($injector, $http, $q, $log, $rootScope, $window, localeConf, localeEvents, localeSupported, localeFallbacks) {
+    .service('locale', function ($injector, $http, $q, $log, $rootScope, $window, localeConf, localeEvents, localeSupported, localeFallbacks, urlBuilder) {
         var TOKEN_REGEX = localeConf.validTokens || new RegExp('^[\\w\\.-]+\\.[\\w\\s\\.-]+\\w(:.*)?$'),
             $html = angular.element(document.body).parent(),
             currentLocale,
@@ -82,7 +82,6 @@ angular.module('ngLocalize')
                 root = bundles,
                 parent,
                 locale = currentLocale,
-                url = localeConf.basePath + '/' + locale,
                 ref,
                 i;
 
@@ -94,16 +93,16 @@ angular.module('ngLocalize')
                     }
                     parent = root;
                     root = root[ref];
-                    url += '/' + ref;
                 }
 
                 if (isFrozen(root)) {
                     root = angular.extend({}, root);
                 }
+				
                 if (!root._loading) {
                     root._loading = true;
-
-                    url += localeConf.fileExtension;
+					
+					var url = urlBuilder.build(localeConf.basePath, locale, path.slice(0, -1), localeConf.fileExtension);
 
                     $http.get(url)
                         .then(function (response) {

--- a/src/localization.urlBuilder.js
+++ b/src/localization.urlBuilder.js
@@ -1,14 +1,12 @@
 angular.module('ngLocalize.UrlBuilder', [])
     .value('urlBuilder', { 
 		build: function(basePath, locale, refs, fileExtension) {
-			if (!angular.isArray(refs))
+			if (!angular.isArray(refs)) {
 				refs = [refs];
+			}
 			
 			var delimiter = '/';
 			
-			return basePath 
-			+ delimiter + locale 
-			+ delimiter + refs.join(delimiter)
-			+ fileExtension;
+			return basePath + delimiter + locale + delimiter + refs.join(delimiter) + fileExtension;
 		}
 	});

--- a/src/localization.urlBuilder.js
+++ b/src/localization.urlBuilder.js
@@ -1,0 +1,14 @@
+angular.module('ngLocalize.UrlBuilder', [])
+    .value('urlBuilder', { 
+		build: function(basePath, locale, refs, fileExtension) {
+			if (!angular.isArray(refs))
+				refs = [refs];
+			
+			var delimiter = '/';
+			
+			return basePath 
+			+ delimiter + locale 
+			+ delimiter + refs.join(delimiter)
+			+ fileExtension;
+		}
+	});


### PR DESCRIPTION
### Problem:
Localization bundles currently can be obtained only via filesystem. Such solution is hardcoded and is not flexible. There are ways to obtain files via endpoints (as my current code does).
### Proposed solution:
Add opportunity to compile url manually. Current implementation moved to 'ngLocalize.UrlBuilder' module, allowing to override it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/doshprompt/angular-localization/109)
<!-- Reviewable:end -->
