### PR TITLE
change $http .success to .then (Angular 1.6 compatibility)

### DIFF
--- a/dist/angular-localization.js
+++ b/dist/angular-localization.js
@@ -127,9 +127,10 @@ angular.module('ngLocalize')
                     url += localeConf.fileExtension;
 
                     $http.get(url)
-                        .success(function (data) {
+                        .then(function (response) {
                             var key,
-                                path = getPath(token);
+                                path = getPath(token),
+                                data= response.data;
                             // Merge the contents of the obtained data into the stored bundle.
                             for (key in data) {
                                 if (data.hasOwnProperty(key)) {
@@ -153,8 +154,7 @@ angular.module('ngLocalize')
                             if (deferrences[path]) {
                                 deferrences[path].resolve(path);
                             }
-                        })
-                        .error(function (err) {
+                        },function (err) {
                             var path = getPath(token);
 
                             $log.error('[localizationService] Failed to load: ' + url);


### PR DESCRIPTION
Angular 1.6 doesn't support .success https://stackoverflow.com/questions/41169385/http-get-success-is-not-a-function

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/doshprompt/angular-localization/116)
<!-- Reviewable:end -->
